### PR TITLE
Fix URL params in htmx, restore no JS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 
 
+## [0.1.3] - 22-02-2025
+
+   * ### Fixed
+     - Fix URL params in htmx, restore no JS support. More details in [pr #4](https://github.com/DmytroLitvinov/django-admin-inline-paginator-plus/pull/4)
+     - Thanks to @pmdevita for these recent releases 👍
+
 ## [0.1.2] - 22-02-2025
 
    * ### Fixed

--- a/django_admin_inline_paginator_plus/templates/admin/paginated_base.html
+++ b/django_admin_inline_paginator_plus/templates/admin/paginated_base.html
@@ -1,4 +1,4 @@
-<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0/dist/htmx.min.js" integrity="sha256-D8V7oOZVUE0oK7bsHD2JJAzenyzhw5PVs4qVxbxtqHU=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js" integrity="sha256-4gndpcgjVHnzFm3vx3UOHbzVpcGAi3eS/C5nM3aPtEc=" crossorigin="anonymous"></script>
 
 <script>
   document.body.addEventListener('htmx:configRequest', function(evt) {

--- a/django_admin_inline_paginator_plus/templates/admin/paginated_base.html
+++ b/django_admin_inline_paginator_plus/templates/admin/paginated_base.html
@@ -1,0 +1,18 @@
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0/dist/htmx.min.js" integrity="sha256-D8V7oOZVUE0oK7bsHD2JJAzenyzhw5PVs4qVxbxtqHU=" crossorigin="anonymous"></script>
+
+<script>
+  document.body.addEventListener('htmx:configRequest', function(evt) {
+    if (!evt.target.classList.contains("pagination-plus-{{ inline_admin_formset.formset.prefix }}")) return
+    let url = new URL(window.location.href)
+    url.searchParams.forEach((value, key, parent) => {
+      if (!evt.detail.parameters.has(key)) {
+        evt.detail.parameters[key] = value
+      }
+    })
+    url.search = ""
+    evt.detail.path = url.href
+  });
+</script>
+
+{% block content %}
+{% endblock content %}

--- a/django_admin_inline_paginator_plus/templates/admin/stacked_paginated.html
+++ b/django_admin_inline_paginator_plus/templates/admin/stacked_paginated.html
@@ -1,9 +1,11 @@
-<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0/dist/htmx.min.js" integrity="sha256-D8V7oOZVUE0oK7bsHD2JJAzenyzhw5PVs4qVxbxtqHU=" crossorigin="anonymous"></script>
+{% extends 'admin/paginated_base.html' %}
 
-<div id="{{ inline_admin_formset.formset.prefix }}-group-wrapper-js">
-  {% include 'admin/edit_inline/stacked.html' %}
+{% block content %}
+  <div id="{{ inline_admin_formset.formset.prefix }}-group-wrapper-js">
+    {% include 'admin/edit_inline/stacked.html' %}
 
-  <div class="admin-stacked-inline-pagination">
-    {% include 'admin/stacked_paginator.html' %}
+    <div class="admin-stacked-inline-pagination">
+      {% include 'admin/stacked_paginator.html' %}
+    </div>
   </div>
-</div>
+{% endblock content %}

--- a/django_admin_inline_paginator_plus/templates/admin/stacked_paginator.html
+++ b/django_admin_inline_paginator_plus/templates/admin/stacked_paginator.html
@@ -8,15 +8,26 @@
   hx-select="#{{ inline_admin_formset.formset.prefix }}-group-wrapper-js"
   hx-target="#{{ inline_admin_formset.formset.prefix }}-group-wrapper-js"
   hx-swap="outerHTML"
+  hx-push-url="true"
 >
   {% with inline_admin_formset.formset.page as page_obj %}
     <p class="paginator">
       {% if page_obj.has_previous %}
-        <a href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}">{% translate 'previous' %}</a>
+        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }}"
+           href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}"
+           hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+           hx-get=""
+          {% hx_vals inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}
+        >{% translate 'previous' %}</a>
       {% endif %}
 
       {% if page_obj.number|add:"-5" > 0 %}
-        <a class="btn-page page-available" href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key 0 %}">1</a>
+        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }} btn-page page-available"
+           href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key 0 %}"
+           hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+           hx-get=""
+          {% hx_vals inline_admin_formset.formset.pagination_key 0 %}
+        >1</a>
       {% endif %}
 
       {% if page_obj.number|add:"-5" > 1 %}
@@ -28,7 +39,12 @@
           <span class="btn-page page-selected">{{ page_num }}</span>
         {% else %}
           {% if page_num > page_obj.number|add:"-5" and page_num < page_obj.number|add:"5" %}
-            <a class="btn-page page-available" href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_num %}">{{ page_num }}</a>
+            <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }} btn-page page-available"
+               href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_num %}"
+               hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+               hx-get=""
+              {% hx_vals inline_admin_formset.formset.pagination_key page_num %}
+            >{{ page_num }}</a>
           {% endif %}
         {% endif %}
       {% endfor %}
@@ -38,11 +54,21 @@
       {% endif %}
 
       {% if page_obj.number|add:"4" < page_obj.paginator.num_pages %}
-        <a class="btn-page page-available" href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.paginator.num_pages %}">{{ page_obj.paginator.num_pages }}</a>
+        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }} btn-page page-available"
+           href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.paginator.num_pages %}"
+           hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+           hx-get=""
+          {% hx_vals inline_admin_formset.formset.pagination_key page_obj.paginator.num_pages %}
+        >{{ page_obj.paginator.num_pages }}</a>
       {% endif %}
 
       {% if page_obj.has_next %}
-        <a href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.next_page_number %}">{% translate 'next' %}</a>
+        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }}"
+           href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.paginator.num_pages %}"
+           hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+           hx-get=""
+          {% hx_vals inline_admin_formset.formset.pagination_key page_obj.next_page_number %}
+        >{% translate 'next' %}</a>
       {% endif %}
       <span class='btn-page results'>{{ page_obj.paginator.count }} {% translate 'Results' %}</span>
     </p>

--- a/django_admin_inline_paginator_plus/templates/admin/tabular_paginated.html
+++ b/django_admin_inline_paginator_plus/templates/admin/tabular_paginated.html
@@ -1,13 +1,14 @@
-<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0/dist/htmx.min.js" integrity="sha256-D8V7oOZVUE0oK7bsHD2JJAzenyzhw5PVs4qVxbxtqHU=" crossorigin="anonymous"></script>
+{% extends 'admin/paginated_base.html' %}
 
+{% block content %}
+  <div
+    id="{{ inline_admin_formset.formset.prefix }}-group-wrapper-js"
 
-<div
-  id="{{ inline_admin_formset.formset.prefix }}-group-wrapper-js"
+  >
+    {% include 'admin/edit_inline/tabular.html' %}
 
->
-  {% include 'admin/edit_inline/tabular.html' %}
-
-  <div class="admin-tabular-inline-pagination">
-    {% include 'admin/tabular_paginator.html' %}
+    <div class="admin-tabular-inline-pagination">
+      {% include 'admin/tabular_paginator.html' %}
+    </div>
   </div>
-</div>
+{% endblock content %}

--- a/django_admin_inline_paginator_plus/templates/admin/tabular_paginator.html
+++ b/django_admin_inline_paginator_plus/templates/admin/tabular_paginator.html
@@ -15,17 +15,22 @@
     <p class="paginator">
       {% if page_obj.has_previous %}
         <a
-          href="javascript:void(0)"
-          hx-get="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}"
+          class="pagination-plus-{{ inline_admin_formset.formset.prefix }}"
+          href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}"
+          hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+          hx-get=""
+          {% hx_vals inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}
         >
           {% translate 'previous' %}
         </a>
       {% endif %}
 
       {% if page_obj.number|add:"-5" > 0 %}
-        <a class="btn-page page-available"
-           href="javascript:void(0)"
-           hx-get="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key 0 %}"
+        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }} btn-page page-available"
+           href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key 0 %}"
+           hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+           hx-get=""
+          {% hx_vals inline_admin_formset.formset.pagination_key 0 %}
         >
           1
         </a>
@@ -40,9 +45,11 @@
           <span class="btn-page page-selected">{{ page_num }}</span>
         {% else %}
           {% if page_num > page_obj.number|add:"-5" and page_num < page_obj.number|add:"5" %}
-            <a class="btn-page page-available"
-               href="javascript:void(0)"
-               hx-get="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_num %}"
+            <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }} btn-page page-available"
+               href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_num %}"
+               hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+               hx-get=""
+              {% hx_vals inline_admin_formset.formset.pagination_key page_num %}
             >
               {{ page_num }}
             </a>
@@ -55,17 +62,24 @@
       {% endif %}
 
       {% if page_obj.number|add:"4" < page_obj.paginator.num_pages %}
-        <a class="btn-page page-available"
-           href="javascript:void(0)"
-           hx-get="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.paginator.num_pages %}">
+        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }} btn-page page-available"
+           href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.next_page_number %}"
+           hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+           hx-get=""
+          {% hx_vals inline_admin_formset.formset.pagination_key page_obj.paginator.num_pages %}
+        >
           {{ page_obj.paginator.num_pages }}
         </a>
       {% endif %}
 
       {% if page_obj.has_next %}
         <a
-          href="javascript:void(0)"
-          hx-get="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.next_page_number %}">
+          class="pagination-plus-{{ inline_admin_formset.formset.prefix }} pagination-plus-{{ inline_admin_formset.formset.prefix }}"
+          href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.next_page_number %}"
+          hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+          hx-get=""
+          {% hx_vals inline_admin_formset.formset.pagination_key page_obj.next_page_number %}
+        >
           {% translate 'next' %}
         </a>
       {% endif %}

--- a/django_admin_inline_paginator_plus/templatetags/paginated_inline.py
+++ b/django_admin_inline_paginator_plus/templatetags/paginated_inline.py
@@ -1,6 +1,7 @@
 import urllib.parse
 
 from django import template
+from django.utils.safestring import SafeString
 
 register = template.Library()
 
@@ -16,3 +17,8 @@ def modify_pagination_path(full_path: str, key: str, value: str) -> str:
     params = urllib.parse.parse_qs(get_params)
     params[key] = [str(value)]
     return urllib.parse.urlencode(params, doseq=True)
+
+
+@register.simple_tag
+def hx_vals(key: str, value):
+    return SafeString(f'hx-vals=\'{{"{key}": {value}}}\'')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-admin-inline-paginator-plus"
-version = "0.1.2"
+version = "0.1.3"
 requires-python = ">=3.8"
 description = "The 'Django Admin Inline Paginator Plus' is simple way to paginate your inlines in Django admin"
 readme = "README.md"


### PR DESCRIPTION
This is my first time using htmx, I'm surprised this required this complicated of a solution so I'll explain here.

This fixes the problem where multiple pagination views (islands) on an admin edit page override each other's URL parameters. This is visible right now in the example in the repo. The original code prior to htmx would update all of the pagination buttons to include existing URL parameters. However, since htmx is just updating the island affected by the pagination change, no other islands are updated. Thus, clicking on another pagination island results in it wiping the other island's parameters out of the URL.

I thought it would be possible to just use `hx-vals` on its own, but it only appends more parameters on to the URL, duplicating existing ones and creating a mess. This is why the JS function is required, it intercepts the request from the pagination buttons, ensures we carry over any existing URL parameters, and cleans the URL, which should avoid duplicates.

A related problem, it would also wipe out any other URL parameters you had. ~~I wasn't able to reproduce #3 but this might help it.~~ It probably won't actually it looks like a separate issue.

Stacked paginator's htmx support should now be complete. I've also restored the original `href` values for links, this should restore functionality in browser environments with no JS (htmx overrides this so it shouldn't cause any issues there).