### PR TITLE
Update tested versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,6 @@ maintainers = [
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
@@ -33,7 +30,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tests/apps_test.py
+++ b/tests/apps_test.py
@@ -17,4 +17,4 @@ class TestDjangoAppConfig(unittest.TestCase):
 
     def test_valid_verbose_name(self):
         verbose_name = DjangoAdminInlinePaginatorPlusConfig.verbose_name
-        self.assertEqual(verbose_name, _('Django Admin Inline Paginator'))
+        self.assertEqual(verbose_name, _('Django Admin Inline Paginator Plus'))

--- a/tox.ini
+++ b/tox.ini
@@ -1,32 +1,39 @@
 [tox]
-envlist = py{38,39}-django{32,40,41,42}
-          py{310}-django{32,40,41,42}
-          py{311}-django{41,42}
+envlist = py39-django{42}
+          py310-django{42,50,51,52}
+          py311-django{42,50,51,52}
+          py312-django{42,50,51,52}
 
 [gh-actions]
 python =
-  3.8: py38
   3.9: py39
   3.10: py310
   3.11: py311
+  3.12: py312
+  3.13: py313
 
 [testenv]
 commands =
-  pytest --cov=django_admin_inline_paginator_plus \
-          --cov-config=tox.ini \
-          --cov-fail-under=35 \
-          --cov-report=term-missing \
-          --cov-report=xml:coverage.xml \
-          --durations=10 \
-          --cov-append
+  python \
+      -W error::ResourceWarning \
+      -W error::DeprecationWarning \
+      -W error::PendingDeprecationWarning \
+      -m pytest \
+      --cov=django_admin_inline_paginator_plus \
+      --cov-config=tox.ini \
+      --cov-fail-under=35 \
+      --cov-report=term-missing \
+      --cov-report=xml:coverage.xml \
+      --durations=10 \
+      --cov-append
 extras = dev
 deps =
   pytest
   pytest-cov
-  django32: Django>=3.2,<4.0
-  django40: Django>=4.0,<4.1
-  django41: Django>=4.1,<4.2
   django42: Django>=4.2,<5.0
+  django50: Django>=5.0a1,<5.1
+  django51: Django>=5.1a1,<5.2
+  django52: Django>=5.2a1,<6.0
 
 [coverage:run]
 relative_files = True


### PR DESCRIPTION
* Drop Python 3.8, which reached EOL 2024-10-07.
* Drop Django 3.2 (EOL 2024-04-01), 4.0 (EOL 2023-04-01), and 4.1 (EOL 2023-12-01).
* Add Python 3.12 and 3.13.
* Add Django 5.2 ([in beta](https://www.djangoproject.com/weblog/2025/feb/19/django-52-beta-1-released/), final release expected April 2nd).

Also correct the one unit test that was failing due to rebranding.