### PR TITLE
make use of htmx configurable

### DIFF
--- a/django_admin_inline_paginator_plus/admin.py
+++ b/django_admin_inline_paginator_plus/admin.py
@@ -30,6 +30,7 @@ class PaginationFormSetBase:
     request: Optional[HttpRequest] = None
     per_page = 20
     pagination_key = 'page'
+    htmx_enabled = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -73,6 +74,7 @@ class InlinePaginated:
     template = 'admin/tabular_paginated.html'
     per_page = 20
     extra = 0
+    htmx_enabled = True
 
     def get_formset(self, request, obj=None, **kwargs):
         formset_class = super().get_formset(request, obj, **kwargs)
@@ -82,6 +84,7 @@ class InlinePaginated:
 
         PaginationFormSet.request = request
         PaginationFormSet.per_page = self.per_page
+        PaginationFormSet.htmx_enabled = self.htmx_enabled
         return PaginationFormSet
 
 

--- a/django_admin_inline_paginator_plus/templates/admin/paginated_base.html
+++ b/django_admin_inline_paginator_plus/templates/admin/paginated_base.html
@@ -1,4 +1,6 @@
+{% if inline_admin_formset.formset.htmx_enabled %}
 <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js" integrity="sha256-4gndpcgjVHnzFm3vx3UOHbzVpcGAi3eS/C5nM3aPtEc=" crossorigin="anonymous"></script>
+{% endif %}
 
 <script>
   document.body.addEventListener('htmx:configRequest', function(evt) {


### PR DESCRIPTION
Added an `htmx_enabled` field to Inlines that defaults to True. Setting to False results in the htmx script not being loaded.

The htmx features are great but, in environments with locked down CSP headers, adding 3rd party scripts won't work.