### PR TITLE
Improve CSS and make template code consistent

### DIFF
--- a/django_admin_inline_paginator_plus/static/django_admin_inline_paginator_plus/paginator.css
+++ b/django_admin_inline_paginator_plus/static/django_admin_inline_paginator_plus/paginator.css
@@ -1,25 +1,28 @@
 .btn-page {
+    display: inline-block;
+    margin: 4px 2px;
+    padding: 2px 6px !important;
     border: none;
-    padding: 5px 10px;
+    border-radius: 4px;
+    color: var(--button-fg);
+    font-size: 12px;
     text-align: center;
     text-decoration: none;
-    display: inline-block;
-    font-size: 12px;
-    margin: 4px 2px;
     cursor: pointer;
 }
 
+.btn-page:hover {
+    background-color: var(--button-hover-bg) !important;
+}
+
 .page-selected {
-    background-color: #ffffff;
-    color: #666;
+    background-color: var(--primary);
 }
 
 .page-available {
     background-color: #008cba;
-    color: white !important;
 }
 
 .results {
-    background-color: #ffffff;
-    color: #666;
+    color: var(--body-fg);
 }

--- a/django_admin_inline_paginator_plus/templates/admin/stacked_paginator.html
+++ b/django_admin_inline_paginator_plus/templates/admin/stacked_paginator.html
@@ -74,7 +74,7 @@
 
       {% if page_obj.has_next %}
         <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }} btn-page page-navigation"
-           href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.paginator.num_pages %}"
+           href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.next_page_number %}"
            hx-params="{{ inline_admin_formset.formset.pagination_key }}"
            hx-get=""
            aria-label="{% translate 'next' %}"

--- a/django_admin_inline_paginator_plus/templates/admin/stacked_paginator.html
+++ b/django_admin_inline_paginator_plus/templates/admin/stacked_paginator.html
@@ -18,6 +18,7 @@
            href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}"
            hx-params="{{ inline_admin_formset.formset.pagination_key }}"
            hx-get=""
+           aria-label="{% translate 'previous' %}"
           {% hx_vals inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}
         >
           &#x23F4;
@@ -76,6 +77,7 @@
            href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.paginator.num_pages %}"
            hx-params="{{ inline_admin_formset.formset.pagination_key }}"
            hx-get=""
+           aria-label="{% translate 'next' %}"
           {% hx_vals inline_admin_formset.formset.pagination_key page_obj.next_page_number %}
         >
           &#x23F5;

--- a/django_admin_inline_paginator_plus/templates/admin/stacked_paginator.html
+++ b/django_admin_inline_paginator_plus/templates/admin/stacked_paginator.html
@@ -14,12 +14,14 @@
     <input type="hidden" name="_paginator-plus-{{ inline_admin_formset.formset.prefix }}" value="{{ page_obj.number }}" />
     <p class="paginator">
       {% if page_obj.has_previous %}
-        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }}"
+        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }} btn-page page-navigation"
            href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}"
            hx-params="{{ inline_admin_formset.formset.pagination_key }}"
            hx-get=""
           {% hx_vals inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}
-        >{% translate 'previous' %}</a>
+        >
+          &#x23F4;
+        </a>
       {% endif %}
 
       {% if page_obj.number|add:"-5" > 0 %}
@@ -28,7 +30,9 @@
            hx-params="{{ inline_admin_formset.formset.pagination_key }}"
            hx-get=""
           {% hx_vals inline_admin_formset.formset.pagination_key 0 %}
-        >1</a>
+        >
+          1
+        </a>
       {% endif %}
 
       {% if page_obj.number|add:"-5" > 1 %}
@@ -45,7 +49,9 @@
                hx-params="{{ inline_admin_formset.formset.pagination_key }}"
                hx-get=""
               {% hx_vals inline_admin_formset.formset.pagination_key page_num %}
-            >{{ page_num }}</a>
+            >
+              {{ page_num }}
+            </a>
           {% endif %}
         {% endif %}
       {% endfor %}
@@ -60,18 +66,22 @@
            hx-params="{{ inline_admin_formset.formset.pagination_key }}"
            hx-get=""
           {% hx_vals inline_admin_formset.formset.pagination_key page_obj.paginator.num_pages %}
-        >{{ page_obj.paginator.num_pages }}</a>
+        >
+          {{ page_obj.paginator.num_pages }}
+        </a>
       {% endif %}
 
       {% if page_obj.has_next %}
-        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }}"
+        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }} btn-page page-navigation"
            href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.paginator.num_pages %}"
            hx-params="{{ inline_admin_formset.formset.pagination_key }}"
            hx-get=""
           {% hx_vals inline_admin_formset.formset.pagination_key page_obj.next_page_number %}
-        >{% translate 'next' %}</a>
+        >
+          &#x23F5;
+        </a>
       {% endif %}
-      <span class='btn-page results'>{{ page_obj.paginator.count }} {% translate 'Results' %}</span>
+      <span class='results'>{{ page_obj.paginator.count }} {% translate 'Results' %}</span>
     </p>
   {% endwith %}
 </div>

--- a/django_admin_inline_paginator_plus/templates/admin/tabular_paginator.html
+++ b/django_admin_inline_paginator_plus/templates/admin/tabular_paginator.html
@@ -4,7 +4,6 @@
 
 <link rel="stylesheet" type="text/css" href="{% static 'django_admin_inline_paginator_plus/paginator.css' %}">
 
-
 <div
   hx-select="#{{ inline_admin_formset.formset.prefix }}-group-wrapper-js"
   hx-target="#{{ inline_admin_formset.formset.prefix }}-group-wrapper-js"
@@ -15,14 +14,14 @@
     <input type="hidden" name="_paginator-plus-{{ inline_admin_formset.formset.prefix }}" value="{{ page_obj.number }}" />
     <p class="paginator">
       {% if page_obj.has_previous %}
-        <a
-          class="pagination-plus-{{ inline_admin_formset.formset.prefix }}"
-          href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}"
-          hx-params="{{ inline_admin_formset.formset.pagination_key }}"
-          hx-get=""
+        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }} btn-page page-navigation"
+           href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}"
+           hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+           hx-get=""
+           disabled="{{ page_obj.has_previous }}"
           {% hx_vals inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}
         >
-          {% translate 'previous' %}
+          &#x23F4;
         </a>
       {% endif %}
 
@@ -74,17 +73,16 @@
       {% endif %}
 
       {% if page_obj.has_next %}
-        <a
-          class="pagination-plus-{{ inline_admin_formset.formset.prefix }} pagination-plus-{{ inline_admin_formset.formset.prefix }}"
-          href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.next_page_number %}"
-          hx-params="{{ inline_admin_formset.formset.pagination_key }}"
-          hx-get=""
+        <a class="pagination-plus-{{ inline_admin_formset.formset.prefix }} btn-page page-navigation"
+           href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.next_page_number %}"
+           hx-params="{{ inline_admin_formset.formset.pagination_key }}"
+           hx-get=""
           {% hx_vals inline_admin_formset.formset.pagination_key page_obj.next_page_number %}
         >
-          {% translate 'next' %}
+          &#x23F5;
         </a>
       {% endif %}
-      <span class='btn-page results'>{{ page_obj.paginator.count }} {% translate 'Results' %}</span>
+      <span class='results'>{{ page_obj.paginator.count }} {% translate 'Results' %}</span>
     </p>
   {% endwith %}
 </div>

--- a/django_admin_inline_paginator_plus/templates/admin/tabular_paginator.html
+++ b/django_admin_inline_paginator_plus/templates/admin/tabular_paginator.html
@@ -18,7 +18,7 @@
            href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}"
            hx-params="{{ inline_admin_formset.formset.pagination_key }}"
            hx-get=""
-           disabled="{{ page_obj.has_previous }}"
+           aria-label="{% translate 'previous' %}"
           {% hx_vals inline_admin_formset.formset.pagination_key page_obj.previous_page_number %}
         >
           &#x23F4;
@@ -77,6 +77,7 @@
            href="?{% modify_pagination_path request.get_full_path inline_admin_formset.formset.pagination_key page_obj.next_page_number %}"
            hx-params="{{ inline_admin_formset.formset.pagination_key }}"
            hx-get=""
+           aria-label="{% translate 'next' %}"
           {% hx_vals inline_admin_formset.formset.pagination_key page_obj.next_page_number %}
         >
           &#x23F5;


### PR DESCRIPTION
Hi @DmytroLitvinov, I made some code changes to improve the CSS to adapt light/dark mode of Django. Let me know if you don't want any change. We can discuss

| Case | Before | After | Note |
|---|---|---|---|
| Dark mode - page 1 | <img width="325" height="52" alt="image" src="https://github.com/user-attachments/assets/bba7bd96-b2ba-4a6d-baff-56d80cb23e83" /> | <img width="281" height="49" alt="image" src="https://github.com/user-attachments/assets/d3eb5005-5d9e-4837-8e28-a9042e2283af" /> | - The selected page has weird size and color<br/>- The "Result" should be a text instead of a button<br/> |
| Dark mode - page n | <img width="421" height="47" alt="image" src="https://github.com/user-attachments/assets/9ad727b6-428f-488c-aabc-2cfd6941e97f" /> | <img width="335" height="52" alt="image" src="https://github.com/user-attachments/assets/dc04b19a-7297-4be3-9348-cef9010cb0a4" /> | - Same as above |
| Light mode - page 1 | <img width="310" height="41" alt="image" src="https://github.com/user-attachments/assets/e6d5eda5-936e-4f34-a226-d853b08390eb" /> | <img width="292" height="60" alt="image" src="https://github.com/user-attachments/assets/90e7e996-0bfc-4bbf-8f2f-2487a8d18fdb" />| |
| Light mode - page n | <img width="415" height="45" alt="image" src="https://github.com/user-attachments/assets/ea8511d0-fb8e-4a4a-ad43-7716a77b96a9" /> | <img width="334" height="52" alt="image" src="https://github.com/user-attachments/assets/c8e14241-1ee4-4af6-a7b3-950c909e1880" /> | |